### PR TITLE
Fixed compile break on pgpFreeDig with RPM 5

### DIFF
--- a/ext/repo_rpmdb.c
+++ b/ext/repo_rpmdb.c
@@ -3027,7 +3027,11 @@ pubkey2solvable(Solvable *s, Repodata *data, char *pubkey)
   repodata_set_str(data, s - s->repo->pool->solvables, PUBKEY_KEYID, keyid);
   if (dig->pubkey.userid)
     setutf8string(data, s - s->repo->pool->solvables, SOLVABLE_SUMMARY, dig->pubkey.userid);
+#ifndef RPM5
   (void)pgpFreeDig(dig);
+#else
+  (void)pgpDigFree(dig);
+#endif
   sat_free((void *)pkts);
   return 1;
 }


### PR DESCRIPTION
RPM5 has renamed some functions, e.g. in the rpmpgp.h file. One, pgpDigNew/pgpNewDig has been caught using a #define, but the other one on pgpDigFree/pgpFreeDig still breaks the build. This simple patch introduces another #ifndef...#else...#endif analgoue to the one used with pgpNewDig/pgpDigNew.
